### PR TITLE
Ameerul /P2PS-1021 When try to block a permanently banned user from advertiser profile , not navigating back to profile page

### DIFF
--- a/packages/p2p/src/components/advertiser-page/advertiser-page.jsx
+++ b/packages/p2p/src/components/advertiser-page/advertiser-page.jsx
@@ -99,6 +99,7 @@ const AdvertiserPage = () => {
                             has_close_icon: false,
                             onClose: () => {
                                 buy_sell_store.hideAdvertiserPage();
+                                history.push(general_store.active_tab_route);
                                 if (general_store.active_index !== 0)
                                     my_profile_store.setActiveTab(my_profile_tabs.MY_COUNTERPARTIES);
                                 advertiser_page_store.onCancel();


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Added the routing back to my profile when user blocks a banned user in advertiser page

### Screenshots:

Please provide some screenshots of the change.
