### PR TITLE
Ameerul /P2PS-1026 After completing one order the amount is showing 0 and the order is still open in responsive view

### DIFF
--- a/packages/p2p/src/stores/order-store.js
+++ b/packages/p2p/src/stores/order-store.js
@@ -330,7 +330,6 @@ export default class OrderStore {
     onUnmount() {
         clearTimeout(this.order_rerender_timeout);
         this.unsubscribeFromCurrentOrder();
-        this.hideDetails(false);
     }
 
     setOrderDetails(response) {


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- removed hideDetails in onUnmount as it also sets the orderID to null, causing issues when the user tries to verify they have paid the order. since it reloads the entire page unMounting the orders page. 
- Checked the order flow, and nothing seems to be broken from removing this check.

### Screenshots:

Please provide some screenshots of the change.
