### PR TITLE
fix: add fallback value for current_fiat_currency

### DIFF
--- a/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.tsx
+++ b/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.tsx
@@ -4,7 +4,7 @@ import { Field, FieldProps, Formik, FormikProps } from 'formik';
 
 import { Button, Icon, Input, Loading, Text } from '@deriv/components';
 import { useCurrentAccountDetails, useExchangeRate } from '@deriv/hooks';
-import { CookieStorage, CryptoConfig, getCurrencyName } from '@deriv/shared';
+import { CryptoConfig, getCurrencyName } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import { Localize, localize } from '@deriv/translations';
 

--- a/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.tsx
+++ b/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.tsx
@@ -4,7 +4,7 @@ import { Field, FieldProps, Formik, FormikProps } from 'formik';
 
 import { Button, Icon, Input, Loading, Text } from '@deriv/components';
 import { useCurrentAccountDetails, useExchangeRate } from '@deriv/hooks';
-import { CryptoConfig, getCurrencyName } from '@deriv/shared';
+import { CookieStorage, CryptoConfig, getCurrencyName } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import { Localize, localize } from '@deriv/translations';
 
@@ -57,7 +57,7 @@ const WithdrawalCryptoForm = observer(() => {
     const {
         balance,
         currency,
-        current_fiat_currency,
+        current_fiat_currency = 'USD',
         verification_code: { payment_withdraw: verification_code },
     } = client;
     const { crypto_fiat_converter, general_store, withdraw } = useCashierStore();


### PR DESCRIPTION
##issue: 
if the clients only has one account ( crypto ) and they want to withdrawal it , the `base_currency` for exchange_rate call would be undefined. that's why I'm passing 'USD'  as the default value for `current_fiat_currency`
